### PR TITLE
[Feat] Allow to install certain browser/webdriver version to image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ At this moment, the following images are available:
 Versions of important packages is written in `/katalon/version` (or `$KATALON_VERSION_FILE`).
 
     cat $KATALON_VERSION_FILE
-    Google Chrome 67.0.3396.62
-    Mozilla Firefox 60.0.1
+    Google Chrome 65.0.3325.181 (ChromeDriver 2.36)
+    Mozilla Firefox 59.0.3 (Geckodriver 0.20.1)
     Katalon Studio 5.4.2
 
 # Katalon Studio image
@@ -45,6 +45,7 @@ If you need to configure proxy for Katalon Studio please use following parameter
 These proxy information will be passed to browsers executing the tests.
 
 For example, the following script will execute a project at `/home/ubuntu/katalon-test` and write reports to `/katalon/katalon/report`. Do not forget to put `--config` before the proxy configuration.
+> If during the test, encountering the "chrome is not reachable", or "failed to decode response from marionette", add the `--privileged -v /dev/shm:/dev/shm --shm-size 2048m` into docker run
 
     #!/usr/bin/env bash
 

--- a/base/src/setup/chrome.sh
+++ b/base/src/setup/chrome.sh
@@ -6,7 +6,9 @@ echo "Install Google Chrome"
 
 package='google-chrome-stable_current_amd64.deb'
 
-wget -O $package  https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+CHROME=65.0.3325.181
+
+wget -O $package  https://www.slimjet.com/chrome/download-chrome.php?file=lnx%2Fchrome64_$CHROME.deb
 dpkg -i $package || apt -y -f install
 rm $package
 

--- a/base/src/setup/firefox.sh
+++ b/base/src/setup/firefox.sh
@@ -4,7 +4,12 @@ set -xe
 
 echo "Install Mozilla Firefox"
 
-apt install -y firefox
+FIREFOX=59.0.3
+
+wget --no-check-certificate https://ftp.mozilla.org/pub/mozilla.org/firefox/releases/$FIREFOX/linux-x86_64/en-US/firefox-$FIREFOX.tar.bz2
+tar -xjf firefox-$FIREFOX.tar.bz2 -C /usr/lib
+ln -s /usr/lib/firefox/firefox /usr/bin/firefox
+rm -rf firefox-$FIREFOX.tar.bz2
 
 # Install 'pulseaudio' package to support WebRTC audio streams
 apt install -y pulseaudio

--- a/base/src/setup/tools.sh
+++ b/base/src/setup/tools.sh
@@ -9,3 +9,4 @@ apt install -y apt-utils
 apt upgrade -y
 apt dist-upgrade -y
 apt install -y wget
+apt install -y bzip2

--- a/katalon/src/scripts/katalon-execute.sh
+++ b/katalon/src/scripts/katalon-execute.sh
@@ -22,7 +22,6 @@ chmod -R 777 $project_dir
 # report
 report_dir=$KATALON_KATALON_ROOT_DIR/report
 mkdir -p $report_dir
-chmod -R 777 $report_dir
 
 # build command line
 project_file=$(find $project_dir -maxdepth 1 -type f -name "*.prj")
@@ -33,3 +32,5 @@ cd $tmp_dir
 eval "$cmd"
 
 cd $current_dir
+chmod -R 777 $KATALON_KATALON_ROOT_DIR/project/Reports/
+chmod -R 777 $report_dir

--- a/katalon/src/scripts/katalon-execute.sh
+++ b/katalon/src/scripts/katalon-execute.sh
@@ -29,8 +29,17 @@ cmd="$KATALON_KATALON_INSTALL_DIR/katalon -runMode=console -reportFolder=$report
 
 $KATALON_BASE_ROOT_DIR/scripts/xvfb.sh start
 cd $tmp_dir
-eval "$cmd"
+eval "$cmd" & pid=$!
+
+wait $pid && retval=0 || retval=$?
 
 cd $current_dir
+
+# grant access
 chmod -R 777 $KATALON_KATALON_ROOT_DIR/project/Reports/
 chmod -R 777 $report_dir
+
+# final exit status
+if [ $retval != 0 ]; then
+    exit $retval;
+fi

--- a/katalon/src/setup/katalon.sh
+++ b/katalon/src/setup/katalon.sh
@@ -2,6 +2,9 @@
 
 set -xe
 
+CHROMEDRIV_VERSION=2.36
+GECKO_VERSION=0.20.1
+
 echo "Install Katalon"
 
 version=5.4.2
@@ -15,6 +18,17 @@ rm $package
 
 mv $KATALON_KATALON_INSTALL_DIR_PARENT/$unzipped_directory $KATALON_KATALON_INSTALL_DIR
 chmod u+x $KATALON_KATALON_INSTALL_DIR/katalon
+
+wget --no-check-certificate https://github.com/mozilla/geckodriver/releases/download/v$GECKO_VERSION/geckodriver-v$GECKO_VERSION-linux64.tar.gz
+tar -xzf geckodriver-v$GECKO_VERSION-linux64.tar.gz -C $KATALON_KATALON_INSTALL_DIR/configuration/resources/drivers/firefox_linux64
+rm -f geckodriver-v$GECKO_VERSION-linux64.tar.gz
+
+wget --no-check-certificate https://chromedriver.storage.googleapis.com/$CHROMEDRIV_VERSION/chromedriver_linux64.zip
+apt-get install unzip
+unzip -o chromedriver_linux64.zip -d $KATALON_KATALON_INSTALL_DIR/configuration/resources/drivers/chromedriver_linux64
+rm -f chromedriver_linux64.zip
+
+chmod u+x $KATALON_KATALON_INSTALL_DIR/configuration/resources/drivers/firefox_linux64/geckodriver
 chmod u+x $KATALON_KATALON_INSTALL_DIR/configuration/resources/drivers/chromedriver_linux64/chromedriver
 
 echo "Katalon Studio $version" >> $KATALON_VERSION_FILE


### PR DESCRIPTION
1. Allow to install certain Chrome version. Suggest to use Chrome 65.0.3325.181
2. Allow to install certain Firefox version. Suggest to use Firefox 59.0.3
3. Allow to update ChromeDriver in Katalon. Suggest to use ChromeDriver 2.36
4. Allow to update GeckoDriver in Katalon. Suggest to use GeckoDriver 0.20.1
5. Change permissions for Katalon Reports folder
6. Update README.md with best practise