### PR TITLE
increase flexibility of XVFB

### DIFF
--- a/src/scripts/katalon-execute.sh
+++ b/src/scripts/katalon-execute.sh
@@ -62,7 +62,7 @@ args+=("-projectPath=$project_prj_file")
 
 cd $workspace_dir
 
-xvfb-run -a -e /dev/stoud $XVFB_ARGS -s "-screen 0 $DISPLAY_CONFIGURATION" "${args[@]}"
+xvfb-run -a -e /dev/stdout $XVFB_ARGS -s "-screen 0 $DISPLAY_CONFIGURATION" "${args[@]}"
 ret_code=$?
 
 #clean up

--- a/src/scripts/katalon-execute.sh
+++ b/src/scripts/katalon-execute.sh
@@ -62,7 +62,7 @@ args+=("-projectPath=$project_prj_file")
 
 cd $workspace_dir
 
-xvfb-run -a -e /dev/stoud XVFB_ARGS -s "-screen 0 $DISPLAY_CONFIGURATION" "${args[@]}"
+xvfb-run -a -e /dev/stoud $XVFB_ARGS -s "-screen 0 $DISPLAY_CONFIGURATION" "${args[@]}"
 ret_code=$?
 
 #clean up

--- a/src/scripts/katalon-execute.sh
+++ b/src/scripts/katalon-execute.sh
@@ -62,7 +62,7 @@ args+=("-projectPath=$project_prj_file")
 
 cd $workspace_dir
 
-xvfb-run -s "-screen 0 $DISPLAY_CONFIGURATION" "${args[@]}"
+xvfb-run -a -e /dev/stoud XVFB_ARGS -s "-screen 0 $DISPLAY_CONFIGURATION" "${args[@]}"
 ret_code=$?
 
 #clean up


### PR DESCRIPTION
When running a custom resolution, i was having problems getting xvfb to run correctly. Turns out you need `-e /dev/stdout` to see why xvfb-run did not work which also lead to using the -a option to let it choose whichever screen works.