### PR TITLE
Add install of apt-transport-https in setup.sh

### DIFF
--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -9,6 +9,7 @@ apt update
 
 echo "Install tools"
 apt -y install apt-utils
+apt -y install apt-transport-https
 apt -y install wget
 apt -y install unzip
 apt -y install curl


### PR DESCRIPTION
Since the Google chrome deb package sets up a HTTPS repo in apt, installing additional packages in a child image will fail with the error: `The method driver /usr/lib/apt/methods/https could not be found`.
To avoid this issue, the `apt-transport-https` package should be installed.

My first ever pull request, apologies in advance if it's not quite the right way to do one :)