### PR TITLE
[STUDIO-2146] Install java 8

### DIFF
--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -15,7 +15,7 @@ apt -y install curl
 apt -y install gosu
 
 echo "Install JRE"
-apt -y install default-jre
+apt -y install openjdk-8-jdk
 
 echo "Install CircleCI tools"
 apt -y install git


### PR DESCRIPTION
Note:
Ubuntu 16.04:
apt install default-jre will install java 8
Ubuntu 20.04:
apt install default-jre will install java 11