### PR TITLE
STUDIO-3537: upgrade to java 17

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ jobs:
     name: Run
     runs-on: ubuntu-latest
     env:
-        KS_VERSION: 8.6.5
+        KS_VERSION: 9.0.0
         KS_VERSION_TAG: latest
     steps:
     - name: Checkout

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,14 +2,14 @@ name: KatalonDockerCI
 on:
   push:
     branches:
-      - master
+      - STUDIO-3537
 jobs:
   run:
     name: Run
     runs-on: ubuntu-latest
     env:
-        KS_VERSION: 8.6.5
-        KS_VERSION_TAG: latest
+        KS_VERSION: 9.0.0
+        KS_VERSION_TAG: test
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -45,8 +45,6 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }} docker.io
-        ./build/tag.sh $KS_VERSION
-        ./build/push.sh $KS_VERSION
         ./build/tag.sh $KS_VERSION_TAG
         ./build/push.sh $KS_VERSION_TAG
     - name: Slack Notification

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,14 +2,14 @@ name: KatalonDockerCI
 on:
   push:
     branches:
-      - STUDIO-3537
+      - master
 jobs:
   run:
     name: Run
     runs-on: ubuntu-latest
     env:
         KS_VERSION: 9.0.0
-        KS_VERSION_TAG: test
+        KS_VERSION_TAG: latest
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -45,6 +45,8 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }} docker.io
+        ./build/tag.sh $KS_VERSION
+        ./build/push.sh $KS_VERSION
         ./build/tag.sh $KS_VERSION_TAG
         ./build/push.sh $KS_VERSION_TAG
     - name: Slack Notification

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,14 +2,14 @@ name: KatalonDockerCI
 on:
   push:
     branches:
-      - STUDIO-3537
+      - master
 jobs:
   run:
     name: Run
     runs-on: ubuntu-latest
     env:
-        KS_VERSION: 9.0.0
-        KS_VERSION_TAG: test
+        KS_VERSION: 8.6.5
+        KS_VERSION_TAG: latest
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -45,6 +45,8 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }} docker.io
+        ./build/tag.sh $KS_VERSION
+        ./build/push.sh $KS_VERSION
         ./build/tag.sh $KS_VERSION_TAG
         ./build/push.sh $KS_VERSION_TAG
     - name: Slack Notification

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,14 +2,14 @@ name: KatalonDockerCI
 on:
   push:
     branches:
-      - master
+      - STUDIO-3537
 jobs:
   run:
     name: Run
     runs-on: ubuntu-latest
     env:
         KS_VERSION: 9.0.0
-        KS_VERSION_TAG: latest
+        KS_VERSION_TAG: test
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -45,8 +45,6 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }} docker.io
-        ./build/tag.sh $KS_VERSION
-        ./build/push.sh $KS_VERSION
         ./build/tag.sh $KS_VERSION_TAG
         ./build/push.sh $KS_VERSION_TAG
     - name: Slack Notification

--- a/src/scripts/setup.sh
+++ b/src/scripts/setup.sh
@@ -15,7 +15,7 @@ apt -y install curl
 apt -y install gosu
 
 echo "Install JRE"
-apt -y install openjdk-8-jdk
+apt -y install openjdk-17-jdk
 
 echo "Install CircleCI tools"
 apt -y install git


### PR DESCRIPTION
## Content
- Katalon Docker Image to use java 17
Tested with the new build, KS version is now 9.0.0, Java version is 17.0.7
<img width="1438" alt="image" src="https://github.com/katalon-studio/docker-images/assets/108044355/cb759d73-d058-498d-a6c5-b76ec5b138bc">

## Ticket references
- [STUDIO-3537](https://katalon.atlassian.net/browse/STUDIO-3537)
## Checklist
- [x] Check base branch
- [x] All requirements are read and clear
- [ ] Tested by Dev field were input
- [x] Verify all code changes are formatted
- [ ] Review SonarCloud code quality report

[STUDIO-3537]: https://katalon.atlassian.net/browse/STUDIO-3537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ