### PR TITLE
CO-2599: Update Katalon base docker image to 1.0.3 (7606921)

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM katalonstudio/ubuntu-20.04:4a27208
+FROM katalonstudio/ubuntu-20.04:7606921
 
 # common environment variables
 ARG KATALON_ROOT_DIR=/katalon


### PR DESCRIPTION
Update Katalon base docker image to 1.0.3 (7606921)

[1.0.3] - 2024-05-01

- Updated Go version to 1.18.1 in setup.sh to fix CVE-2023-XXXX. (PR: https://github.com/katalon-studio/katalon-golden-image/pull/63)
- Image: katalonstudio/ubuntu-20.04:7606921